### PR TITLE
fix: log without state

### DIFF
--- a/crates/automations/src/automations/credential_offer.rs
+++ b/crates/automations/src/automations/credential_offer.rs
@@ -40,7 +40,7 @@ impl CredentialOfferAutomation {
             + Send
             + Sync,
     ) -> Result<()> {
-        info!({ "message": "Starting automation CredentialOfferAutomation" });
+        info!({ "message": "Starting automation" });
         trace!({
            "connection_id": self.connection_id,
             "attributes": self.attributes
@@ -74,9 +74,7 @@ impl CredentialOfferAutomation {
 
         let credential_definition = create_credential_definition.execute(&agent).await?;
 
-        info!({
-           "message": "Offering the credential..."
-        });
+        info!({ "message": "Offering the credential..." });
 
         let credential_offer_response = agent
             .send_offer(CredentialOfferOptions {

--- a/crates/cli/src/modules/automation.rs
+++ b/crates/cli/src/modules/automation.rs
@@ -107,7 +107,7 @@ pub async fn parse_automation_args(
                     info!({ "message": "Credential offer" });
                     println!();
 
-                    info!({
+                    log!({
                         "message":
                             format!(
                                 "{} invitation with connection id {}.",
@@ -116,7 +116,7 @@ pub async fn parse_automation_args(
                             )
                     });
                     println!();
-                    info!({"message": "Use this URL", "invitation_url": connection.invitation_url });
+                    log!({"message": "Use this URL", "invitation_url": connection.invitation_url });
                     println!();
                     println!();
                     info!({

--- a/crates/cli/src/modules/configuration.rs
+++ b/crates/cli/src/modules/configuration.rs
@@ -76,7 +76,7 @@ pub fn parse_configuration_args(options: &ConfigurationOptions) -> Result<()> {
                 Box::<dyn std::error::Error>::from(error::Error::CannotReadConfigurationFile)
             })?;
             info!({ "coniguration_path": config_path });
-            info!({ "output": output });
+            log!({ "output": output });
             Ok(())
         }
         ConfigurationSubcommands::Add {
@@ -90,7 +90,7 @@ pub fn parse_configuration_args(options: &ConfigurationOptions) -> Result<()> {
             if *default {
                 let (environment, configuration) = Configuration::init(token.clone());
                 Configuration::add(environment, configuration)?;
-                info!({
+                log!({
                     "message": "Successfully added the default agent",
                     "configuration_path": config_path
                 });
@@ -107,7 +107,7 @@ pub fn parse_configuration_args(options: &ConfigurationOptions) -> Result<()> {
                 // TODO: this can only be aca-py or afj
                 agent: agent.clone(),
             };
-            info!({
+            log!({
                 "message":
                     format!(
                         "Writing {}: {} to {}",
@@ -117,7 +117,7 @@ pub fn parse_configuration_args(options: &ConfigurationOptions) -> Result<()> {
                     )
             });
             Configuration::add(environment.clone(), env)?;
-            info!({
+            log!({
                 "message":
                     format!(
                         "Successfully Added agent {} at {}.",
@@ -130,7 +130,7 @@ pub fn parse_configuration_args(options: &ConfigurationOptions) -> Result<()> {
             Ok(())
         }
         ConfigurationSubcommands::Remove { environment } => {
-            debug!({
+            log!({
                 "message":
                     format!(
                         "{} environment {} from the configuration",
@@ -139,7 +139,7 @@ pub fn parse_configuration_args(options: &ConfigurationOptions) -> Result<()> {
                     )
             });
             Configuration::remove(environment.clone())?;
-            info!({
+            log!({
                 "message":
                     format!(
                         "{} {} from the configuration",

--- a/crates/cli/src/modules/connection.rs
+++ b/crates/cli/src/modules/connection.rs
@@ -117,14 +117,13 @@ pub async fn parse_connection_args(
             agent.create_invitation(options).await.map(|response| {
                 loader.stop();
                 info!({ "message": "Created invititation"});
-                info!({ "connection_id": response.id});
+                log!({ "connection_id": response.id});
                 if *qr {
                     info!({"message": "Scan this QR code to accept the invitation"});
                     print_qr_code(&response.invitation_url).unwrap();
-                } else {
-                    info!({ "message": "Another agent can use this URL to accept your invitation"});
-                    info!({ "invitation_url": &response.invitation_url});
                 }
+                info!({ "message": "Another agent can use this URL to accept your invitation"});
+                log!({ "invitation_url": &response.invitation_url});
                 copy!("{}", response.invitation_url);
             })
         }
@@ -136,7 +135,7 @@ pub async fn parse_connection_args(
                 .map(|connection| {
                     debug!({ "connection": connection });
                     info!({"message": "Fetched connection id"});
-                    info!({ "connection_id": connection.id });
+                    log!({ "connection_id": connection.id });
                 })
         }
         ConnectionSubcommands::List {
@@ -152,7 +151,7 @@ pub async fn parse_connection_args(
             Some(i) => agent.get_by_id(i.clone()).await.map(|connection| {
                 loader.stop();
                 copy!("{}", pretty_stringify_obj(&connection));
-                info!({ "connection": connection });
+                log!({ "connection": connection });
             }),
             None => {
                 let options = ConnectionGetAllOptions {
@@ -171,7 +170,7 @@ pub async fn parse_connection_args(
                 agent.get_all(options).await.map(|connections| {
                     loader.stop();
                     copy!("{}", pretty_stringify_obj(&connections));
-                    info!({ "connections": connections });
+                    log!({ "connections": connections });
                 })
             }
         },

--- a/crates/cli/src/modules/credential.rs
+++ b/crates/cli/src/modules/credential.rs
@@ -66,7 +66,7 @@ pub async fn parse_credentials_args(
                 loader.stop();
                 debug!({ "credential": credential });
                 info!({ "message": "Successefully offered a credential" });
-                info!({ "credential_exchange_id": credential.credential_exchange_id });
+                log!({ "credential_exchange_id": credential.credential_exchange_id });
             })
         }
     }

--- a/crates/cli/src/modules/credential_definition.rs
+++ b/crates/cli/src/modules/credential_definition.rs
@@ -74,7 +74,7 @@ pub async fn parse_credential_definition_args(
                 loader.stop();
                 copy!("{}", cred_def.credential_definition_id);
                 info!({ "message": "Created credential definition" });
-                info!({ "credential_definition_id": cred_def.credential_definition_id });
+                log!({ "credential_definition_id": cred_def.credential_definition_id });
             })
         }
         CredentialDefinitionSubcommands::List { id } => match id {
@@ -89,7 +89,7 @@ pub async fn parse_credential_definition_args(
                 });
                 debug!({ "credential_definition": cred_def });
                 copy!("{}", pretty_stringify_obj(&loggable));
-                info!({ "credential_definition": loggable });
+                log!({ "credential_definition": loggable });
             }),
 
             None => agent.get_all().await.map(|cred_defs| {

--- a/crates/cli/src/modules/feature.rs
+++ b/crates/cli/src/modules/feature.rs
@@ -15,7 +15,7 @@ pub async fn parse_features_args(agent: impl FeatureModule + Send + Sync) -> Res
     agent.discover_features().await.map(|features| {
         loader.stop();
         debug!({ "features": features });
-        info!({
+        log!({
             "protocols": features.disclose.protocols
         });
     })

--- a/crates/cli/src/modules/multitenancy.rs
+++ b/crates/cli/src/modules/multitenancy.rs
@@ -39,7 +39,7 @@ pub async fn parse_multitenancy_args(
     match &options.commands {
         MultitenancySubcommands::Create {} => agent.create().await.map(|response| {
             loader.stop();
-            info!({ "response": response });
+            log!({ "response": response });
             copy!("{}", response.wallet_id);
         }),
         MultitenancySubcommands::Remove { wallet_id } => {

--- a/crates/cli/src/modules/proof.rs
+++ b/crates/cli/src/modules/proof.rs
@@ -57,7 +57,7 @@ pub async fn parse_proof_args(
                     (
                         p.0.clone(),
                         p.1.clone(),
-                        p.2.parse::<i32>()
+                        p.2.parse()
                             .map_err(|_| Error::PredicateValueNonNumber(p.0.clone(), p.2.clone()))
                             .unwrap(),
                     )
@@ -74,7 +74,8 @@ pub async fn parse_proof_args(
                 .await
                 .map(|proof| {
                     debug!({ "proof": proof });
-                    info!({ "message": "Successefully requested a proof", "presentation_exchange_id": &proof.presentation_exchange_id});
+                    info!({ "message": "Successefully requested a proof"});
+                    log!({ "presentation_exchange_id": &proof.presentation_exchange_id });
                     copy!("{}", &proof.presentation_exchange_id);
                 })?;
             loader.stop();

--- a/crates/cli/src/modules/schema.rs
+++ b/crates/cli/src/modules/schema.rs
@@ -70,14 +70,14 @@ pub async fn parse_schema_args(
                     .attr_names
                     .into_iter()
                     .for_each(|name| info!({ "schema_name": name }));
-                info!({ "schema_id": schema.id});
+                log!({ "schema_id": schema.id});
                 copy!("{}", schema.id);
             })
         }
         SchemaSubcommands::List { id } => match id {
             Some(i) => agent.get_by_id(i.clone()).await.map(|schema| {
                 loader.stop();
-                info!({ "schema": schema });
+                log!({ "schema": schema });
                 copy!("{}", pretty_stringify_obj(&schema));
             }),
             None => agent.get_all().await.map(|schemas| {
@@ -85,7 +85,7 @@ pub async fn parse_schema_args(
                 schemas
                     .schema_ids
                     .iter()
-                    .for_each(|schema_id| info!({ "schema_id": schema_id }));
+                    .for_each(|schema_id| log!({ "schema_id": schema_id }));
                 info!({ "message": "Successfully fetched schema IDs" });
             }),
         },

--- a/crates/cli/src/modules/wallet.rs
+++ b/crates/cli/src/modules/wallet.rs
@@ -127,7 +127,7 @@ pub async fn parse_wallet_args(
                 .map(|response: DidList| {
                     loader.stop();
                     info!({ "message": "Found the following DID information"});
-                    info!({ "response": response });
+                    log!({ "response": response });
                     copy!("{}", pretty_stringify_obj(&response));
                 })
         }
@@ -141,7 +141,7 @@ pub async fn parse_wallet_args(
             agent.create_local_did(options).await.map(|response| {
                 loader.stop();
                 info!({ "message": format!("Successfully created local DID: {:?}", response.did) });
-                info!({ "response": response });
+                log!({ "response": response });
                 copy!("{}", pretty_stringify_obj(&response));
             })
         }
@@ -149,21 +149,21 @@ pub async fn parse_wallet_args(
             agent.rotate_keypair(did.clone()).await.map(|response| {
                 loader.stop();
                 info!({ "message": format!("Successfully rotated keypair for DID: {did}") });
-                info!({ "response": response });
+                log!({ "response": response });
                 copy!("{}", pretty_stringify_obj(response));
             })
         }
         WalletSubcommands::FetchPublicDid {} => agent.fetch_public_did().await.map(|response| {
             loader.stop();
             info!({ "message": "Wallet public DID" });
-            info!({ "response": response });
+            log!({ "response": response });
             copy!("{}", pretty_stringify_obj(&response));
         }),
         WalletSubcommands::AssignPublicDid { did } => {
             agent.assign_public_did(did.clone()).await.map(|response| {
                 loader.stop();
                 info!({ "message": "Successfully assigned public DID" });
-                info!({ "response": response });
+                log!({ "response": response });
                 copy!("{}", pretty_stringify_obj(&response));
             })
         }
@@ -171,7 +171,7 @@ pub async fn parse_wallet_args(
             agent.fetch_did_endpoint(did.clone()).await.map(|response| {
                 loader.stop();
                 info!({ "message": format!("DID endpoint for DID: {did}") });
-                info!({ "response": response });
+                log!({ "response": response });
                 copy!("{}", pretty_stringify_obj(&response));
             })
         }
@@ -188,7 +188,7 @@ pub async fn parse_wallet_args(
             agent.set_did_endpoint(options).await.map(|response| {
                 loader.stop();
                 info!({ "message": format!("Set DID endpoint for DID: {did}") });
-                info!({ "response": response });
+                log!({ "response": response });
                 copy!("{}", pretty_stringify_obj(response));
             })
         }

--- a/crates/cli/src/modules/webhook.rs
+++ b/crates/cli/src/modules/webhook.rs
@@ -37,7 +37,7 @@ pub async fn parse_webhook_args(agent: impl WebhookModule + Send + Sync) -> Resu
                     )
                 },
             );
-            info!({ "webhook_message": incoming_webhook_message, "event": event});
+            log!({ "webhook_message": incoming_webhook_message, "event": event});
         })
         .await
 }

--- a/crates/cli/src/register.rs
+++ b/crates/cli/src/register.rs
@@ -27,9 +27,10 @@ pub async fn register() -> Result<()> {
         LogLevel::Off
     } else {
         match cli.verbose {
+            1 => LogLevel::Info,
             2 => LogLevel::Debug,
             3.. => LogLevel::Trace,
-            _ => LogLevel::Info,
+            _ => LogLevel::default(),
         }
     };
 

--- a/crates/logger/src/lib.rs
+++ b/crates/logger/src/lib.rs
@@ -2,7 +2,7 @@
 //! Only cli bindings for now
 
 use cli_clipboard::{ClipboardContext, ClipboardProvider};
-use colored::Colorize;
+use colored::{ColoredString, Colorize};
 use serde::Serialize;
 use std::sync::RwLock;
 
@@ -27,6 +27,9 @@ pub enum LogLevel {
     /// Log warnings and above
     Warn,
 
+    /// zero state
+    None,
+
     /// Log info and above
     #[default]
     Info,
@@ -49,6 +52,7 @@ impl LogLevel {
             Self::Debug => "debug".bold().blue(),
             Self::Trace => "trace".bold().purple(),
             Self::Off => "off".green(),
+            Self::None => ColoredString::default(),
         };
         s.to_string()
     }
@@ -63,6 +67,7 @@ impl LogLevel {
             Self::Debug => "debug",
             Self::Trace => "trace",
             Self::Off => "off",
+            Self::None => "",
         };
         s.to_string()
     }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -35,7 +35,6 @@ mod e2e_tests {
     use super::utils::helpers::{run_test, REGEX_UUID};
     use regex::Regex;
     use speculoos::prelude::*;
-    use tokio::io::AsyncReadExt;
 
     test! { smoke |cli| {
         let re = Regex::new(r"^siera \d\.\d.\d").unwrap();


### PR DESCRIPTION
Fixed some of the logs. Some logs do not need a prefix as they are a MUST output for the command. (think of connection id of `siera connection receive`). Everything else is info, debug or trace.