### PR TITLE
build(coverage): no threshold

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,12 +3,6 @@ coverage:
   range: 85..100
   round: down
   precision: 1
-  status:
-    # ref: https://docs.codecov.com/docs/commit-status
-    project:
-      default:
-        # Avoid false negatives
-        threshold: 1%
 
 # Test files aren't important for coverage
 ignore:


### PR DESCRIPTION
It was failing because of the threshold, its not required for now.